### PR TITLE
fix: typo error linea 21

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
     <footer class="footer">
         
-        <div class="conteiner">
+        <div class="container">
             
             <div class="footer-link">
 


### PR DESCRIPTION
Corregir error de tipeo en el nombre de la clase:
cambiar 'conteiner' por 'container'.